### PR TITLE
feature: 검색 리스트 Paging3 -> 컴포즈 MoreList 노출방식으로 변경.

### DIFF
--- a/core/designsystem/src/main/kotlin/com/eosr14/kakao/search/core/designsystem/component/KakaoSearchItem.kt
+++ b/core/designsystem/src/main/kotlin/com/eosr14/kakao/search/core/designsystem/component/KakaoSearchItem.kt
@@ -22,7 +22,6 @@ import com.eosr14.kakao.search.core.designsystem.theme.TextType
 import com.eosr14.kakao.search.core.designsystem.type.KakaoSearchItemType
 import com.eosr14.kakao.search.core.extension.SIMPLE_DATE_FORMAT_TYPE2
 import com.eosr14.kakao.search.core.extension.toFormatString
-import kotlinx.coroutines.flow.Flow
 
 @Composable
 fun KakaoSearchItem(
@@ -31,8 +30,7 @@ fun KakaoSearchItem(
     playTime: Long? = null,
     onClickItem: () -> Unit,
     columnContent: @Composable ColumnScope.() -> Unit,
-//    hasBookmark: Flow<Boolean>,
-    hasBookmark: Boolean? = null,
+    hasBookmark: Boolean = false,
     onClickBookmark: (() -> Unit)? = null,
 ) {
     Column(
@@ -85,9 +83,9 @@ fun KakaoSearchItem(
                 columnContent()
             }
 
-            if (hasBookmark != null && onClickBookmark != null) {
+            onClickBookmark?.let {
                 IconButton(
-                    onClick = { onClickBookmark() },
+                    onClick = { it() },
                 ) {
                     Icon(
                         painter = if (hasBookmark) {
@@ -157,7 +155,7 @@ fun ImageColumnContent(
 @Composable
 fun VideoColumnContent(
     title: String,
-    author: String,
+    author: String?,
     dateTime: String
 ) {
     Text(
@@ -166,10 +164,12 @@ fun VideoColumnContent(
         maxLines = 2,
         overflow = TextOverflow.Ellipsis
     )
-    Text(
-        text = author,
-        style = TextType.Medium18_B(),
-    )
+    author?.let {
+        Text(
+            text = it,
+            style = TextType.Medium18_B(),
+        )
+    }
     Text(
         text = dateTime,
         style = TextType.Medium18_R(),

--- a/core/model/src/main/kotlin/com/eosr14/kakao/search/core/model/Bookmark.kt
+++ b/core/model/src/main/kotlin/com/eosr14/kakao/search/core/model/Bookmark.kt
@@ -4,10 +4,11 @@ import com.eosr14.kakao.search.core.designsystem.type.KakaoSearchItemType
 import java.util.*
 
 data class Bookmark(
-    val url: String,
+    val uniqueField: String,
     val type: KakaoSearchItemType,
     val thumbnailUrl: String,
     val title: String,
+    val url: String,
     val author: String? = null,
     val dateTime: Date
 )

--- a/core/preferences/src/main/kotlin/com/eosr14/kakao/search/core/preferences/repository/BookmarkRepository.kt
+++ b/core/preferences/src/main/kotlin/com/eosr14/kakao/search/core/preferences/repository/BookmarkRepository.kt
@@ -5,7 +5,7 @@ import com.eosr14.kakao.search.core.model.Bookmark
 
 interface BookmarkRepository {
     fun getBookmarks(): List<Bookmark>
-    fun addBookmark(bookmark: Bookmark)
-    fun deleteBookmark(uniqueField: String)
+    fun addBookmark(bookmark: Bookmark, onSuccessUpdate: () -> Unit)
+    fun deleteBookmark(uniqueField: String, onSuccessUpdate: () -> Unit)
     fun hasBookmark(uniqueField: String): Boolean
 }

--- a/core/preferences/src/main/kotlin/com/eosr14/kakao/search/core/preferences/repository/BookmarkRepositoryImpl.kt
+++ b/core/preferences/src/main/kotlin/com/eosr14/kakao/search/core/preferences/repository/BookmarkRepositoryImpl.kt
@@ -4,8 +4,6 @@ import com.eosr14.kakao.search.core.extension.moshi.fromListJson
 import com.eosr14.kakao.search.core.extension.moshi.toJson
 import com.eosr14.kakao.search.core.model.Bookmark
 import com.eosr14.kakao.search.core.preferences.AppPreferences
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
 
 internal class BookmarkRepositoryImpl @Inject constructor(
@@ -14,26 +12,27 @@ internal class BookmarkRepositoryImpl @Inject constructor(
 
     override fun getBookmarks(): List<Bookmark> = preferences.bookmarks.fromListJson()
 
-    override fun addBookmark(bookmark: Bookmark) {
+    override fun addBookmark(bookmark: Bookmark, onSuccessUpdate: () -> Unit) {
         with(getBookmarks().toMutableList()) {
             add(bookmark)
-            updateBookmarks()
+            updateBookmarks(onSuccessUpdate)
         }
     }
 
-    override fun deleteBookmark(uniqueField: String) {
+    override fun deleteBookmark(uniqueField: String, onSuccessUpdate: () -> Unit) {
         with(getBookmarks().toMutableList()) {
-            removeIf { it.url == uniqueField }
-            updateBookmarks()
+            removeIf { it.uniqueField == uniqueField }
+            updateBookmarks(onSuccessUpdate)
         }
     }
 
     override fun hasBookmark(uniqueField: String): Boolean =
-        getBookmarks().find { it.url == uniqueField } != null
+        getBookmarks().find { it.uniqueField == uniqueField } != null
 
-    private fun List<Bookmark>.updateBookmarks() {
+    private fun List<Bookmark>.updateBookmarks(onSuccessUpdate: () -> Unit) {
         toJson()?.let {
             preferences.bookmarks = it
+            onSuccessUpdate()
         }
     }
 }

--- a/feature/bookmark/src/main/kotlin/com/eosr14/kakao/search/feature/bookmark/ui/KakaoBookmarkScreen.kt
+++ b/feature/bookmark/src/main/kotlin/com/eosr14/kakao/search/feature/bookmark/ui/KakaoBookmarkScreen.kt
@@ -20,7 +20,9 @@ import androidx.compose.ui.viewinterop.AndroidViewBinding
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.eosr14.kakao.search.core.designsystem.component.ImageColumnContent
 import com.eosr14.kakao.search.core.designsystem.component.KakaoSearchItem
+import com.eosr14.kakao.search.core.designsystem.component.VideoColumnContent
 import com.eosr14.kakao.search.core.designsystem.theme.TextType
+import com.eosr14.kakao.search.core.designsystem.type.KakaoSearchItemType
 import com.eosr14.kakao.search.core.extension.startExternalUrl
 import com.eosr14.kakao.search.core.extension.toFormatString
 import com.eosr14.kakao.search.core.model.Bookmark
@@ -81,10 +83,17 @@ fun BookmarkList(
                 thumbnailPath = it.thumbnailUrl,
                 onClickItem = { context.startExternalUrl(it.url) },
                 columnContent = {
-                    ImageColumnContent(
-                        title = it.title,
-                        dateTime = it.dateTime.toFormatString()
-                    )
+                    when (it.type) {
+                        KakaoSearchItemType.IMAGE -> ImageColumnContent(
+                            title = it.title,
+                            dateTime = it.dateTime.toFormatString()
+                        )
+                        KakaoSearchItemType.VIDEO -> VideoColumnContent(
+                            title = it.title,
+                            author = it.author,
+                            dateTime = it.dateTime.toFormatString()
+                        )
+                    }
                 }
             )
         }

--- a/feature/bookmark/src/main/kotlin/com/eosr14/kakao/search/feature/bookmark/ui/KakaoBookmarkViewModel.kt
+++ b/feature/bookmark/src/main/kotlin/com/eosr14/kakao/search/feature/bookmark/ui/KakaoBookmarkViewModel.kt
@@ -18,7 +18,6 @@ class KakaoBookmarkViewModel @Inject internal constructor(
 
     private val _bookmarks = MutableStateFlow<List<Bookmark>>(listOf())
     val bookmarks: StateFlow<List<Bookmark>> = _bookmarks.asStateFlow()
-
     fun getBookmarks() {
         viewModelScope.launch {
             val bookmarks = bookmarkRepository.getBookmarks()

--- a/feature/home/src/main/kotlin/com/eosr14/kakao/search/feature/home/paging/LazyListState.kt
+++ b/feature/home/src/main/kotlin/com/eosr14/kakao/search/feature/home/paging/LazyListState.kt
@@ -1,0 +1,26 @@
+package com.eosr14.kakao.search.feature.home.paging
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.*
+
+@Composable
+fun LazyListState.OnBottomReached(
+    loadMore: () -> Unit
+) {
+    val shouldLoadMore = remember {
+        derivedStateOf {
+            val lastVisibleItem =
+                layoutInfo.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf true
+            lastVisibleItem.index == layoutInfo.totalItemsCount - 1
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore) {
+        snapshotFlow { shouldLoadMore.value }
+            .collect {
+                if (it) {
+                    loadMore()
+                }
+            }
+    }
+}

--- a/feature/home/src/main/kotlin/com/eosr14/kakao/search/feature/home/ui/KakaoHomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/eosr14/kakao/search/feature/home/ui/KakaoHomeScreen.kt
@@ -3,6 +3,8 @@ package com.eosr14.kakao.search.feature.home.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -15,10 +17,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidViewBinding
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.paging.compose.LazyPagingItems
-import androidx.paging.compose.collectAsLazyPagingItems
-import androidx.paging.compose.items
 import com.eosr14.kakao.search.core.designsystem.component.*
+import com.eosr14.kakao.search.core.designsystem.type.KakaoSearchItemType
 import com.eosr14.kakao.search.core.extension.startExternalUrl
 import com.eosr14.kakao.search.core.extension.toFormatString
 import com.eosr14.kakao.search.core.model.Image
@@ -26,6 +26,7 @@ import com.eosr14.kakao.search.core.model.SearchItem
 import com.eosr14.kakao.search.core.model.Video
 import com.eosr14.kakao.search.core.model.toBookmarkItem
 import com.eosr14.kakao.search.feature.home.databinding.FragmentKakaoHomeBinding
+import com.eosr14.kakao.search.feature.home.paging.OnBottomReached
 
 
 @Composable
@@ -37,74 +38,40 @@ fun KakaoHomeFragmentInCompose() {
 fun KakaoHomeScreen(
     viewModel: KakaoHomeViewModel = hiltViewModel()
 ) {
-    val searchItems: LazyPagingItems<SearchItem> =
-        viewModel.getSearchItems().collectAsLazyPagingItems()
-    val context = LocalContext.current
-    val onClickItem: (String) -> Unit = { context.startExternalUrl(it) }
-
+    val searchItems = viewModel.searchItems
+    val listState = rememberLazyListState()
     LazyColumn(
+        state = listState,
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
         item {
             SearchTextField {
-                searchItems.refresh()
+                with(viewModel) {
+                    getSearchItems()
+                    getBookmarks()
+                }
             }
         }
         item {
             Spacer(modifier = Modifier.size(10.dp))
         }
-        items(searchItems) { searchItems ->
-            searchItems?.let {
-                when (it) {
-                    is Image -> {
-                        val title = stringResource(
-                            id = com.eosr14.kakao.search.core.designsystem.R.string.collection,
-                            it.collection,
-                            it.displaySiteName
-                        )
-                        KakaoSearchItem(type = it.type,
-                            thumbnailPath = it.thumbnailUrl,
-                            onClickItem = { onClickItem(it.docUrl) },
-                            columnContent = {
-                                ImageColumnContent(
-                                    title = title,
-                                    dateTime = it.dateTime.toFormatString()
-                                )
-                            },
-                            hasBookmark = viewModel.hasBookmark(it.uniqueField),
-                            onClickBookmark = {
-                                viewModel.onClickBookmark(it.toBookmarkItem(title), it)
-                            })
-                    }
 
-                    is Video -> {
-                        val title = it.title
-                        KakaoSearchItem(type = it.type,
-                            thumbnailPath = it.thumbnail,
-                            playTime = it.playTime,
-                            onClickItem = { onClickItem(it.url) },
-                            columnContent = {
-                                VideoColumnContent(
-                                    title = title,
-                                    author = it.author,
-                                    dateTime = it.dateTime.toFormatString()
-                                )
-                            },
-                            hasBookmark = viewModel.hasBookmark(it.uniqueField),
-                            onClickBookmark = {
-                                viewModel.onClickBookmark(it.toBookmarkItem(title), it)
-                            })
-                    }
-                }
-            }
+
+        itemsIndexed(searchItems) { index, item ->
+            SearchItem(index = index, item = item)
         }
+    }
+
+    listState.OnBottomReached {
+        viewModel.updateMoreItems()
     }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun SearchTextField(
-    viewModel: KakaoHomeViewModel = hiltViewModel(), onClickSearch: () -> Unit
+    viewModel: KakaoHomeViewModel = hiltViewModel(),
+    onClickSearch: () -> Unit
 ) {
     val textState = viewModel.text
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -124,3 +91,117 @@ private fun SearchTextField(
         },
         onValueChange = { viewModel.setSearchText(it) })
 }
+
+@Composable
+private fun SearchItem(
+    item: SearchItem,
+    index: Int,
+    viewModel: KakaoHomeViewModel = hiltViewModel()
+) {
+    val context = LocalContext.current
+    val onClickItem: (String) -> Unit = { context.startExternalUrl(it) }
+
+    when (item) {
+        is Image -> {
+            val title = stringResource(
+                id = com.eosr14.kakao.search.core.designsystem.R.string.collection,
+                item.collection,
+                item.displaySiteName
+            )
+            KakaoSearchItem(
+                type = item.type,
+                thumbnailPath = item.thumbnailUrl,
+                onClickItem = { onClickItem(item.docUrl) },
+                columnContent = {
+                    ImageColumnContent(
+                        title = title,
+                        dateTime = item.dateTime.toFormatString()
+                    )
+                },
+                hasBookmark = item.hasBookmark,
+                onClickBookmark = {
+                    viewModel.onClickBookmark(
+                        item.toBookmarkItem(title),
+                        index,
+                        KakaoSearchItemType.IMAGE
+                    )
+                })
+        }
+
+        is Video -> {
+            val title = item.title
+            KakaoSearchItem(
+                type = item.type,
+                thumbnailPath = item.thumbnail,
+                playTime = item.playTime,
+                onClickItem = { onClickItem(item.url) },
+                columnContent = {
+                    VideoColumnContent(
+                        title = title,
+                        author = item.author,
+                        dateTime = item.dateTime.toFormatString()
+                    )
+                },
+                hasBookmark = item.hasBookmark,
+                onClickBookmark = {
+                    viewModel.onClickBookmark(
+                        item.toBookmarkItem(title),
+                        index,
+                        KakaoSearchItemType.VIDEO
+                    )
+                })
+        }
+    }
+}
+
+/**
+ * Compose Paging3 라이브러리를 사용하는 경우, 단일 아이템의 업데이트를 처리할 방법이 없습니다.
+ * Bookmark UI Update처리를 위하여 Paging3을 사용하지 않고 인피니티 스크롤 처리를 진행하였습니다.
+ */
+//@Composable
+//private fun SearchItemWithPaging(
+//    item: SearchItem?,
+//    viewModel: KakaoHomeViewModel = hiltViewModel()
+//) {
+//    val context = LocalContext.current
+//    val onClickItem: (String) -> Unit = { context.startExternalUrl(it) }
+//    item?.let {
+//        when (it) {
+//            is Image -> {
+//                val title = stringResource(
+//                    id = com.eosr14.kakao.search.core.designsystem.R.string.collection,
+//                    it.collection,
+//                    it.displaySiteName
+//                )
+//                KakaoSearchItem(type = it.type,
+//                    thumbnailPath = it.thumbnailUrl,
+//                    onClickItem = { onClickItem(it.docUrl) },
+//                    columnContent = {
+//                        ImageColumnContent(
+//                            title = title,
+//                            dateTime = it.dateTime.toFormatString()
+//                        )
+//                    },
+//                    hasBookmark = it.hasBookmark,
+//                    onClickBookmark = { viewModel.onClickBookmark(it.toBookmarkItem(title)) })
+//            }
+//
+//            is Video -> {
+//                val title = it.title
+//                KakaoSearchItem(type = it.type,
+//                    thumbnailPath = it.thumbnail,
+//                    playTime = it.playTime,
+//                    onClickItem = { onClickItem(it.url) },
+//                    columnContent = {
+//                        VideoColumnContent(
+//                            title = title,
+//                            author = it.author,
+//                            dateTime = it.dateTime.toFormatString()
+//                        )
+//                    },
+//                    hasBookmark = it.hasBookmark,
+//                    onClickBookmark = { viewModel.onClickBookmark(it.toBookmarkItem(title)) })
+//            }
+//        }
+//    }
+//}

--- a/feature/home/src/main/kotlin/com/eosr14/kakao/search/feature/home/ui/KakaoHomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/eosr14/kakao/search/feature/home/ui/KakaoHomeViewModel.kt
@@ -1,12 +1,10 @@
 package com.eosr14.kakao.search.feature.home.ui
 
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
+import com.eosr14.kakao.search.core.designsystem.type.KakaoSearchItemType
 import com.eosr14.kakao.search.core.model.Bookmark
 import com.eosr14.kakao.search.core.model.Image
 import com.eosr14.kakao.search.core.model.SearchItem
@@ -14,10 +12,8 @@ import com.eosr14.kakao.search.core.model.Video
 import com.eosr14.kakao.search.core.network.service.KakaoService
 import com.eosr14.kakao.search.core.network.utils.NETWORK_DEFAULT_SIZE
 import com.eosr14.kakao.search.core.preferences.repository.BookmarkRepository
-import com.eosr14.kakao.search.feature.home.paging.KakaoPagingResult
-import com.eosr14.kakao.search.feature.home.paging.KakaoPagingSource
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,42 +25,70 @@ class KakaoHomeViewModel @Inject internal constructor(
     private val _text = mutableStateOf("")
     val text get() = _text.value
 
-    fun getSearchItems(): Flow<PagingData<SearchItem>> = Pager(
-        config = PagingConfig(
-            initialLoadSize = NETWORK_DEFAULT_SIZE,
-            pageSize = NETWORK_DEFAULT_SIZE,
-            enablePlaceholders = false
-        ),
-        initialKey = null,
-        pagingSourceFactory = {
-            KakaoPagingSource { page, size ->
-                if (text.isEmpty()) {
-                    return@KakaoPagingSource KakaoPagingResult(null, listOf())
-                }
-                val apiSize = size / 2
-                val images = service.getImages(query = text, page = page, size = apiSize)
-                val videos = service.getVideos(query = text, page = page, size = apiSize)
-                KakaoPagingResult(page, sortBySearchItems(images.documents, videos.documents))
-            }
-        }
-    )
-        .flow
-        .cachedIn(viewModelScope)
+    private val page = mutableStateOf(1)
 
+    var searchItems = mutableStateListOf<SearchItem>()
+
+    fun getSearchItems() = requestItems()
+
+    fun updateMoreItems() {
+        if (text.isEmpty()) {
+            return
+        }
+        requestItems()
+    }
 
     fun setSearchText(textState: String) {
         _text.value = textState
     }
 
-    fun onClickBookmark(bookmark: Bookmark, searchItem: SearchItem) {
-        if (hasBookmark(bookmark.url)) {
-            bookmarkRepository.deleteBookmark(bookmark.url)
+
+    fun onClickBookmark(
+        bookmark: Bookmark,
+        index: Int,
+        type: KakaoSearchItemType
+    ) {
+        if (hasBookmark(bookmark.uniqueField)) {
+            bookmarkRepository.deleteBookmark(bookmark.uniqueField) {
+                updateBookmark(index, type, false)
+            }
         } else {
-            bookmarkRepository.addBookmark(bookmark)
+            bookmarkRepository.addBookmark(bookmark) {
+                updateBookmark(index, type, true)
+            }
         }
     }
 
-    fun hasBookmark(uniqueField: String): Boolean = bookmarkRepository.hasBookmark(uniqueField)
+
+    fun getBookmarks() {
+        bookmarkRepository.getBookmarks()
+    }
+
+    private fun hasBookmark(uniqueField: String): Boolean =
+        bookmarkRepository.hasBookmark(uniqueField)
+
+    private fun updateBookmark(
+        updateIndex: Int,
+        type: KakaoSearchItemType,
+        hasBookmark: Boolean
+    ) {
+        val item = when (type) {
+            KakaoSearchItemType.IMAGE -> (searchItems[updateIndex] as Image).copy(hasBookmark = hasBookmark)
+            KakaoSearchItemType.VIDEO -> (searchItems[updateIndex] as Video).copy(hasBookmark = hasBookmark)
+        }
+        searchItems[updateIndex] = item
+    }
+
+    private fun requestItems() {
+        val apiSize = NETWORK_DEFAULT_SIZE / 2
+        val apiPage = page.value
+        viewModelScope.launch {
+            val images = service.getImages(query = text, page = apiPage, size = apiSize)
+            val videos = service.getVideos(query = text, page = apiPage, size = apiSize)
+            searchItems.addAll(sortBySearchItems(images.documents, videos.documents))
+            page.value = page.value + 1
+        }
+    }
 
     private fun sortBySearchItems(
         images: List<Image>,
@@ -72,4 +96,40 @@ class KakaoHomeViewModel @Inject internal constructor(
     ): List<SearchItem> {
         return (images + videos).sortedByDescending { it.sortTime }
     }
+
+
+    /**
+     * Compose Paging3 라이브러리를 사용하는 경우, 단일 아이템의 업데이트를 처리할 방법이 없습니다.
+     * Bookmark UI Update처리를 위하여 Paging3을 사용하지 않고 인피니티 스크롤 처리를 진행하였습니다.
+     */
+//    private val _searchItems = MutableStateFlow<List<SearchItem>>(listOf())
+//    val searchItems: StateFlow<List<SearchItem>> = _searchItems.asStateFlow()
+
+//    val items: Flow<PagingData<SearchItem>> = Pager(
+//        config = PagingConfig(
+//            initialLoadSize = NETWORK_DEFAULT_SIZE,
+//            pageSize = NETWORK_DEFAULT_SIZE,
+//            enablePlaceholders = false
+//        ),
+//        initialKey = null,
+//        pagingSourceFactory = {
+//            KakaoPagingSource { page, size ->
+//                if (text.isEmpty()) {
+//                    return@KakaoPagingSource KakaoPagingResult(null, listOf())
+//                }
+//                val apiSize = size / 2
+//                val images = service.getImages(query = text, page = page, size = apiSize)
+//                val videos = service.getVideos(query = text, page = page, size = apiSize)
+//                KakaoPagingResult(page, sortBySearchItems(images.documents, videos.documents))
+//            }
+//        })
+//        .flow
+//        .map { pagingData ->
+//            pagingData.map {
+//                it.apply {
+//                    it.hasBookmark = hasBookmark(it.uniqueField)
+//                }
+//            }
+//        }
+//        .cachedIn(viewModelScope)
 }


### PR DESCRIPTION
### 수정사항
 - 검색 리스트 Paging3 -> 컴포즈 MoreList 노출방식으로 변경.
   - Compose Paging3 라이브러리를 사용하는 경우, 단일 아이템의 업데이트를 처리할 방법이 없습니다.
   - Bookmark UI Update처리를 위하여 Paging3을 사용하지 않고 인피니티 스크롤 처리를 진행하였습니다.